### PR TITLE
Fix NPM token check in GitHub Actions workflow by updating the secret…

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -52,13 +52,11 @@ jobs:
             - name: Check NPM Token
               id: check_token
               run: |
-                  if [ -z "${{ secrets.NPM_TOKEN2 }}" ]; then
+                  if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
                     echo "NPM_TOKEN is not set"
-                    echo "has_token=false" >> $GITHUB_OUTPUT
                     exit 1
                   else
                     echo "NPM_TOKEN is set"
-                    echo "has_token=true" >> $GITHUB_OUTPUT
                   fi
 
             - name: Release version on GitHub


### PR DESCRIPTION
… reference from NPM_TOKEN2 to NPM_TOKEN for accurate authentication before publishing packages.